### PR TITLE
Raise path exceptions without wrapping in FaultTolerantExecutor

### DIFF
--- a/fault-tolerant-executor-resilience4j/src/main/java/com/mx/path/service/facility/fault_tolerant_executor/Resilience4jFaultTolerantExecutor.java
+++ b/fault-tolerant-executor-resilience4j/src/main/java/com/mx/path/service/facility/fault_tolerant_executor/Resilience4jFaultTolerantExecutor.java
@@ -12,6 +12,8 @@ import com.mx.common.configuration.Configuration;
 import com.mx.common.connect.ConnectException;
 import com.mx.common.connect.ServiceUnavailableException;
 import com.mx.common.connect.TooManyRequestsException;
+import com.mx.common.exception.PathRequestException;
+import com.mx.common.exception.PathSystemException;
 import com.mx.common.process.FaultTolerantExecutor;
 import com.mx.common.process.FaultTolerantTask;
 import com.mx.path.service.facility.fault_tolerant_executor.configuration.Configurations;
@@ -32,6 +34,7 @@ public final class Resilience4jFaultTolerantExecutor implements FaultTolerantExe
     this.scopedConfigurationRegistry.initializeFromConfigurations(configurations);
   }
 
+  @SuppressWarnings("PMD.CyclomaticComplexity")
   @Override
   public void submit(String scope, FaultTolerantTask task) {
     try {
@@ -48,6 +51,8 @@ public final class Resilience4jFaultTolerantExecutor implements FaultTolerantExe
       throw new com.mx.common.connect.TimeoutException(
           "Resilience4j triggered a timeout.",
           e);
+    } catch (PathRequestException | PathSystemException e) {
+      throw e; // rethrow Path exceptions
     } catch (Exception e) {
       throw new ConnectException(
           "An unknown error occurred",


### PR DESCRIPTION
# Summary of Changes

We should not wrap path exceptions raised inside of fault tolerant block.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
