### PR TITLE
Rename store redis connectionTimeout to timeout

### DIFF
--- a/store-redis/src/main/java/com/mx/path/service/facility/store/redis/RedisStore.java
+++ b/store-redis/src/main/java/com/mx/path/service/facility/store/redis/RedisStore.java
@@ -127,7 +127,7 @@ public class RedisStore implements Store {
           .computationThreadPoolSize(configuration.getComputationThreadPoolSize())
           .build();
 
-      RedisClient redisClient = RedisClient.create(resources, new RedisURI(configuration.getHost(), configuration.getPort(), configuration.getConnectionTimeout()));
+      RedisClient redisClient = RedisClient.create(resources, new RedisURI(configuration.getHost(), configuration.getPort(), configuration.getTimeout()));
 
       // RESP3 executes a HELLO command to discover the protocol before executing any commands made by the client.
       // This can cause issues if we are communicating over a proxy and the proxy doesn't speak RESP3. For now, it is safer

--- a/store-redis/src/main/java/com/mx/path/service/facility/store/redis/RedisStoreConfiguration.java
+++ b/store-redis/src/main/java/com/mx/path/service/facility/store/redis/RedisStoreConfiguration.java
@@ -11,7 +11,7 @@ public class RedisStoreConfiguration {
 
   private static final String DEFAULT_HOST = "localhost";
   private static final int DEFAULT_COMPUTATION_THREAD_POOL_SIZE = 5;
-  private static final Duration DEFAULT_CONNECTION_TIMEOUT = Duration.ofSeconds(10);
+  private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
   private static final int DEFAULT_PORT = 6379;
   private static final int DEFAULT_THREAD_POOL_SIZE = 5;
 
@@ -22,7 +22,7 @@ public class RedisStoreConfiguration {
   private int computationThreadPoolSize = DEFAULT_COMPUTATION_THREAD_POOL_SIZE;
 
   @ConfigurationField
-  private Duration connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
+  private Duration timeout = DEFAULT_TIMEOUT;
 
   @ConfigurationField
   private int ioThreadPoolSize = DEFAULT_THREAD_POOL_SIZE;

--- a/upgrades/v3.0.0/facilities-3.0.0-upgrade.sh
+++ b/upgrades/v3.0.0/facilities-3.0.0-upgrade.sh
@@ -66,6 +66,7 @@ function process_file {
     "com.mx.path.service.facility.fault_tolerant_executor([^a-zA-Z])=com.mx.path.service.facility.fault_tolerant_executor.resilience4j\1"
     "com.mx.path.facility.exception_reporter.honeybadger([^a-zA-Z])=com.mx.path.service.facility.exception_reporter.honeybadger\1"
     "com.mx.path.facility.security.vault([^a-zA-Z])=com.mx.path.service.facility.security.vault\1"
+    "connectionTimeout([^a-zA-Z])=timeout\1"
   )
 
   local reported_file=false


### PR DESCRIPTION
# Summary of Changes

The redis-store `connectionTimeout` configuration was incorrectly named. Renaming to `timeout`. Added the fix to the v3 upgrade script.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
