### PR TITLE
fix: change visibility of vault encryption service authentication type enum

### DIFF
--- a/encryption-service-vault/src/main/java/com/mx/path/service/facility/security/vault/VaultEncryptionServiceConfiguration.java
+++ b/encryption-service-vault/src/main/java/com/mx/path/service/facility/security/vault/VaultEncryptionServiceConfiguration.java
@@ -8,7 +8,7 @@ import com.mx.common.configuration.ConfigurationField;
 
 @Data
 public class VaultEncryptionServiceConfiguration {
-  enum AuthenticationType {
+  public enum AuthenticationType {
     @Deprecated
     APPID,
     APPROLE,


### PR DESCRIPTION
This enum is part of the configuration and should be public.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
