### PR TITLE
docs: make v3 upgrade script rerunnable with resilience4j

### DIFF
--- a/upgrades/v3.0.0/facilities-3.0.0-upgrade.sh
+++ b/upgrades/v3.0.0/facilities-3.0.0-upgrade.sh
@@ -63,7 +63,7 @@ function process_file {
     "com.mx.redis([^a-zA-Z])=com.mx.path.service.facility.store.redis\1"
     "com.mx.path.facility.store.vault([^a-zA-Z])=com.mx.path.service.facility.store.vault\1"
     "com.mx.messaging.nats([^a-zA-Z])=com.mx.path.service.facility.messaging.nats\1"
-    "com.mx.path.service.facility.fault_tolerant_executor([^a-zA-Z])=com.mx.path.service.facility.fault_tolerant_executor.resilience4j\1"
+    "com.mx.path.service.facility.fault_tolerant_executor.Resilience4jFaultTolerantExecutor=com.mx.path.service.facility.fault_tolerant_executor.resilience4j.Resilience4jFaultTolerantExecutor"
     "com.mx.path.facility.exception_reporter.honeybadger([^a-zA-Z])=com.mx.path.service.facility.exception_reporter.honeybadger\1"
     "com.mx.path.facility.security.vault([^a-zA-Z])=com.mx.path.service.facility.security.vault\1"
     "connectionTimeout([^a-zA-Z])=timeout\1"


### PR DESCRIPTION
When the v3 upgrade script was rerun, it would mess up the package path for the Resilience4JExecutor.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
