### PR TITLE
fix: update minVersion on vault's `/config` endpoint

### DIFF
--- a/encryption-service-vault/src/main/java/com/mx/path/service/facility/security/vault/VaultEncryptionService.java
+++ b/encryption-service-vault/src/main/java/com/mx/path/service/facility/security/vault/VaultEncryptionService.java
@@ -190,7 +190,7 @@ public class VaultEncryptionService implements EncryptionService {
   }
 
   /**
-   * Set the minimum decryption key, minimum encryption key and minimum available version
+   * Set the minimum decryption key and minimum encryption key
    *
    * <p>Does not raise exception on failure.
    *
@@ -200,8 +200,7 @@ public class VaultEncryptionService implements EncryptionService {
     try {
       VaultResponse response = logicalWriteWithReauthentication("transit/keys/" + configuration.getKeyName() + "/config", ImmutableMap.of(
           "min_decryption_version", minVersion,
-          "min_encryption_version", minVersion,
-          "min_available_version", minVersion));
+          "min_encryption_version", minVersion));
       validateVaultOperationResponse(response, "Unable to update vault key");
     } catch (RuntimeException e) {
       LOGGER.warn("Unable to update vault key", e);

--- a/encryption-service-vault/src/test/groovy/com/mx/path/service/facility/security/vault/VaultEncryptionServiceTest.groovy
+++ b/encryption-service-vault/src/test/groovy/com/mx/path/service/facility/security/vault/VaultEncryptionServiceTest.groovy
@@ -18,13 +18,12 @@ import com.bettercloud.vault.api.Logical
 import com.bettercloud.vault.response.AuthResponse
 import com.bettercloud.vault.response.LogicalResponse
 import com.bettercloud.vault.rest.RestResponse
-import com.mx.path.core.common.collection.ObjectMap
+import com.google.common.collect.ImmutableMap
 
 import spock.lang.Specification
 import spock.lang.Unroll
 
 class VaultEncryptionServiceTest extends Specification {
-  ObjectMap configuration
   Logical logicalDriver
   VaultEncryptionService subject
   Vault vaultDriver
@@ -458,7 +457,10 @@ class VaultEncryptionServiceTest extends Specification {
     when:
     subject.rotateKeys()
     verify(logicalDriver).write("transit/keys/" + config.getKeyName() + "/rotate", null)
-    verify(logicalDriver).write("transit/keys/" + config.getKeyName(), Collections.singletonMap("min_decryption_version", 2))
+    verify(logicalDriver).write("transit/keys/" + config.getKeyName() + "/config", ImmutableMap.of(
+        "min_available_version", 3,
+        "min_decryption_version", 3,
+        "min_encryption_version", 3))
 
     then:
     true
@@ -497,13 +499,16 @@ class VaultEncryptionServiceTest extends Specification {
   }
 
   @Unroll
-  def "setMinDecryptionVersion() interacts with driver"() {
+  def "setMinVersion() interacts with driver"() {
     when:
     subject = new VaultEncryptionService(config)
     subject.setDriver(vaultDriver)
 
-    subject.setMinDecryptionVersion(12)
-    verify(logicalDriver).write("transit/keys/" + config.getKeyName(), Collections.singletonMap("min_decryption_version", 12))
+    subject.setMinVersion(12)
+    verify(logicalDriver).write("transit/keys/" + config.getKeyName() + "/config", ImmutableMap.of(
+        "min_available_version", 12,
+        "min_decryption_version", 12,
+        "min_encryption_version", 12))
 
     then:
     true

--- a/encryption-service-vault/src/test/groovy/com/mx/path/service/facility/security/vault/VaultEncryptionServiceTest.groovy
+++ b/encryption-service-vault/src/test/groovy/com/mx/path/service/facility/security/vault/VaultEncryptionServiceTest.groovy
@@ -458,7 +458,6 @@ class VaultEncryptionServiceTest extends Specification {
     subject.rotateKeys()
     verify(logicalDriver).write("transit/keys/" + config.getKeyName() + "/rotate", null)
     verify(logicalDriver).write("transit/keys/" + config.getKeyName() + "/config", ImmutableMap.of(
-        "min_available_version", 3,
         "min_decryption_version", 3,
         "min_encryption_version", 3))
 
@@ -506,7 +505,6 @@ class VaultEncryptionServiceTest extends Specification {
 
     subject.setMinVersion(12)
     verify(logicalDriver).write("transit/keys/" + config.getKeyName() + "/config", ImmutableMap.of(
-        "min_available_version", 12,
         "min_decryption_version", 12,
         "min_encryption_version", 12))
 


### PR DESCRIPTION
set min_decryption_version and min_encryption_version

# Summary of Changes

use `/config` endpoint instead of `/<named_key>` endpoint to update min values

Fixes # [MC-1669](https://mxcom.atlassian.net/browse/MC-1669)

## Public API Additions/Changes

None

## Downstream Consumer Impact

This will now properly set min values on keys so that older keys can be trimmed

# How Has This Been Tested?

Validated in sand

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works


[MC-1669]: https://mxcom.atlassian.net/browse/MC-1669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ