### PR TITLE
feat: 🎸 Vault TLS

### DIFF
--- a/encryption-service-vault/src/main/java/com/mx/path/service/facility/security/vault/VaultEncryptionService.java
+++ b/encryption-service-vault/src/main/java/com/mx/path/service/facility/security/vault/VaultEncryptionService.java
@@ -11,6 +11,7 @@ import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 
+import com.bettercloud.vault.SslConfig;
 import com.bettercloud.vault.Vault;
 import com.bettercloud.vault.VaultConfig;
 import com.bettercloud.vault.VaultException;
@@ -134,21 +135,42 @@ public class VaultEncryptionService implements EncryptionService {
    */
   final Vault buildVaultDriver(@Nullable String authToken) {
     try {
-      VaultConfig vaultConfig = new VaultConfig()
-          .token(authToken)
-          .engineVersion(configuration.getEngineVersion())
-          .address(configuration.getUri())
-          .build();
+      if (configuration.isSsl()) { // If SSL is enabled, set up the SSL configuration
+        SslConfig sslConfig = new SslConfig();
+        sslConfig.verify(false);
+        VaultConfig vaultConfig = new VaultConfig()
+            .sslConfig(sslConfig)
+            .token(authToken)
+            .engineVersion(configuration.getEngineVersion())
+            .address(configuration.getUri())
+            .build();
 
-      Vault newDriver = new Vault(vaultConfig);
+        Vault newDriver = new Vault(vaultConfig);
 
-      if (configuration.getMaxRetries() > 0) {
-        newDriver.withRetries(
-            configuration.getMaxRetries(),
-            Math.toIntExact(configuration.getRetryInterval().toMillis()));
+        if (configuration.getMaxRetries() > 0) {
+          newDriver.withRetries(
+              configuration.getMaxRetries(),
+              Math.toIntExact(configuration.getRetryInterval().toMillis()));
+        }
+
+        return newDriver;
+      } else {
+        VaultConfig vaultConfig = new VaultConfig()
+            .token(authToken)
+            .engineVersion(getConfiguration().getEngineVersion())
+            .address(getConfiguration().getUri())
+            .build();
+
+        Vault newDriver = new Vault(vaultConfig);
+
+        if (getConfiguration().getMaxRetries() > 0) {
+          newDriver.withRetries(
+              getConfiguration().getMaxRetries(),
+              Math.toIntExact(getConfiguration().getRetryInterval().toMillis()));
+        }
+
+        return newDriver;
       }
-
-      return newDriver;
     } catch (VaultException e) {
       throw new VaultEncryptionConfigurationException("Unable to build Vault Encryption Configuration", e);
     }

--- a/encryption-service-vault/src/main/java/com/mx/path/service/facility/security/vault/VaultEncryptionServiceConfiguration.java
+++ b/encryption-service-vault/src/main/java/com/mx/path/service/facility/security/vault/VaultEncryptionServiceConfiguration.java
@@ -22,6 +22,7 @@ public class VaultEncryptionServiceConfiguration {
   private static final AuthenticationType DEFAULT_AUTHENTICATION = AuthenticationType.APPROLE;
   private static final String DEFAULT_KEY_NAME = "vault_session";
   private static final int DEFAULT_NUM_KEYS_TO_KEEP_COUNT = 1;
+  private static final boolean DEFAULT_SSL_ENABLED = false;
 
   @ConfigurationField
   private boolean enabled = true;
@@ -58,6 +59,9 @@ public class VaultEncryptionServiceConfiguration {
 
   @ConfigurationField(secret = true)
   private String token;
+
+  @ConfigurationField(value = "ssl-enabled")
+  private boolean ssl = DEFAULT_SSL_ENABLED;
 
   @ConfigurationField
   private AuthenticationType authentication = DEFAULT_AUTHENTICATION;

--- a/encryption-service-vault/src/test/groovy/com/mx/path/service/facility/security/vault/VaultEncryptionServiceTest.groovy
+++ b/encryption-service-vault/src/test/groovy/com/mx/path/service/facility/security/vault/VaultEncryptionServiceTest.groovy
@@ -72,6 +72,20 @@ class VaultEncryptionServiceTest extends Specification {
     }
   }
 
+  def configWithAppRoleSSL() {
+    return new VaultEncryptionServiceConfiguration().tap {
+      setUri("http://localhost:8200")
+      setEnabled(true)
+      setAuthentication(VaultEncryptionServiceConfiguration.AuthenticationType.APPROLE)
+      setAppRole("role-k8s")
+      setSecretId("secretId")
+      setKeyName("test-key")
+      setMaxRetries(2)
+      setNumKeysToKeep(3)
+      setSsl(true)
+    }
+  }
+
   def "on first use, creates and authenticates driver once"() {
     given:
     def config = configWithAppId()
@@ -113,10 +127,11 @@ class VaultEncryptionServiceTest extends Specification {
     driver.getClass() == Vault
 
     where:
-    config              | _
-    configWithAppId()   | _
-    configWithToken()   | _
-    configWithAppRole() | _
+    config                  | _
+    configWithAppId()       | _
+    configWithToken()       | _
+    configWithAppRole()     | _
+    configWithAppRoleSSL()  | _
   }
 
   @Unroll

--- a/store-vault/src/main/java/com/mx/path/service/facility/store/vault/VaultStoreConfiguration.java
+++ b/store-vault/src/main/java/com/mx/path/service/facility/store/vault/VaultStoreConfiguration.java
@@ -26,6 +26,7 @@ public class VaultStoreConfiguration {
   private static final Duration DEFAULT_RETRY_INTERVAL = Duration.ofMillis(200);
   private static final int KEY_NOT_FOUND = 404;
   private static final int MAXIMUM_REAUTHENTICATION_RETRIES = 3;
+  private static final boolean DEFAULT_SSL_ENABLED = false;
 
   @ConfigurationField(value = "app-id")
   private String appId;
@@ -47,6 +48,9 @@ public class VaultStoreConfiguration {
 
   @ConfigurationField(secret = true)
   private String secretId;
+
+  @ConfigurationField(value = "ssl-enabled")
+  private boolean ssl = DEFAULT_SSL_ENABLED;
 
   @ConfigurationField(secret = true)
   private String token;

--- a/store-vault/src/test/groovy/com/mx/path/service/facility/store/vault/VaultStoreTest.groovy
+++ b/store-vault/src/test/groovy/com/mx/path/service/facility/store/vault/VaultStoreTest.groovy
@@ -62,6 +62,17 @@ class VaultStoreTest extends Specification {
     }
   }
 
+  def configWithAppRoleSSL() {
+    return new VaultStoreConfiguration().tap {
+      setUri("http://localhost:8200")
+      setAuthentication(VaultStoreConfiguration.AuthenticationType.APPROLE)
+      setAppRole("role-k8s")
+      setSecretId("secretId")
+      setMaxRetries(2)
+      setSsl(true)
+    }
+  }
+
   def "on first use, creates and authenticates driver once"() {
     given:
     def config = configWithAppId()
@@ -103,10 +114,11 @@ class VaultStoreTest extends Specification {
     driver.getClass() == Vault
 
     where:
-    config              | _
-    configWithAppId()   | _
-    configWithToken()   | _
-    configWithAppRole() | _
+    config                  | _
+    configWithAppId()       | _
+    configWithToken()       | _
+    configWithAppRole()     | _
+    configWithAppRoleSSL()  | _
   }
 
   def "buildVaultDriver with invalid configuration"() {


### PR DESCRIPTION
Add vault tls for connections

# Summary of Changes

Addes ability to connect to vault that require TLS

Fixes # (issue)

## Public API Additions/Changes


## Downstream Consumer Impact

No impact to existing connection as default will still be to not use TLS

# How Has This Been Tested?

Testing has been done in `generic-app-java` using the same bettercloud vault driver to test connections using both non-tls and tls connections

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
