### PR TITLE
fix: 🐛 Redis Cluster Refresh

### DIFF
--- a/store-redis/src/main/java/com/mx/path/service/facility/store/redis/RedisStore.java
+++ b/store-redis/src/main/java/com/mx/path/service/facility/store/redis/RedisStore.java
@@ -1,9 +1,12 @@
 package com.mx.path.service.facility.store.redis;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import lombok.Getter;
 
 import com.mx.path.core.common.configuration.Configuration;
@@ -223,10 +226,15 @@ public class RedisStore implements Store {
           .build();
 
       RedisClusterClient redisClusterClient = RedisClusterClient.create(resources, redisUri);
+      ClusterTopologyRefreshOptions topologyRefreshOptions = ClusterTopologyRefreshOptions.builder()
+          .enablePeriodicRefresh(Duration.ofMinutes(3))
+          .enableAllAdaptiveRefreshTriggers()
+          .build();
       SslOptions sslOptions = SslOptions.builder()
           .keyManager(new File(configuration.getCertFile()), new File(configuration.getKeyFile()), configuration.getPasswordFile().toCharArray())
           .build();
       ClusterClientOptions clusterClientOptions = ClusterClientOptions.builder()
+          .topologyRefreshOptions(topologyRefreshOptions)
           .sslOptions(sslOptions).build();
       redisClusterClient.setOptions(clusterClientOptions);
 


### PR DESCRIPTION
Refresh the redis cluster connections so if a new host is added or removed the list is refreshed

# Summary of Changes

During issues when a redis host is lost or added the cluster list is not being updated. This will add a background check to update the redis clust list

Fixes # (issue)

## Public API Additions/Changes

Please include a description of any new or modified publicly available classes and/or methods (if applicable).

## Downstream Consumer Impact

